### PR TITLE
Correct class names referenced in log/exception

### DIFF
--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultEncounterSetGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultEncounterSetGenerator.java
@@ -110,10 +110,10 @@ public class QueryResultEncounterSetGenerator extends CRCDAO implements
 			}
 		} catch (SQLException sqlEx) {
 			exception = sqlEx;
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("QueryResultEncounterSetGenerator.generateResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultEncounterSetGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 
 		} catch (Throwable throwable) {

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultGenerator.java
@@ -260,10 +260,10 @@ public class QueryResultGenerator extends CRCDAO implements IResultGenerator {
 		} catch (Exception sqlEx) {
 
 			errorFlag = true;
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("QueryResultGenerator.generateResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientAgeCountGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientAgeCountGenerator.java
@@ -115,10 +115,10 @@ public class QueryResultPatientAgeCountGenerator extends CRCDAO implements
 					.toString());
 
 		} catch (Exception sqlEx) {
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("QueryResultPatientAgeCountGenerator.generateResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultPatientAgeCountGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 			IQueryResultInstanceDao resultInstanceDao = sfDAOFactory

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientCountGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientCountGenerator.java
@@ -87,10 +87,10 @@ public class QueryResultPatientCountGenerator extends CRCDAO implements
 					strWriter.toString());
 		} catch (Exception sqlEx) {
 			log.error(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultPatientCountGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultPatientCountGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 			IQueryResultInstanceDao resultInstanceDao = sfDAOFactory

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientGenderCountGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientGenderCountGenerator.java
@@ -82,10 +82,10 @@ public class QueryResultPatientGenderCountGenerator extends CRCDAO implements
 					.toString());
 
 		} catch (Exception sqlEx) {
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("QueryResultPatientGenderCountGenerator.generateResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultPatientGenderCountGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 			IQueryResultInstanceDao resultInstanceDao = sfDAOFactory

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientRaceCdCountGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientRaceCdCountGenerator.java
@@ -80,10 +80,10 @@ public class QueryResultPatientRaceCdCountGenerator extends CRCDAO implements
 					.toString());
 
 		} catch (Exception sqlEx) {
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("QueryResultPatientRaceCdCountGenerator.generateResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultPatientRaceCdCountGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 			IQueryResultInstanceDao resultInstanceDao = sfDAOFactory

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientVitalCdCountGenerator.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryResultPatientVitalCdCountGenerator.java
@@ -81,10 +81,10 @@ public class QueryResultPatientVitalCdCountGenerator extends CRCDAO implements
 					.toString());
 
 		} catch (Exception sqlEx) {
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("QueryResultPatientVitalCdCountGenerator.generateResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"QueryResultPatientVitalCdCountGenerator.generateResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 			IQueryResultInstanceDao resultInstanceDao = sfDAOFactory

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/exec/CalulatePatientCountMainFromItemKey.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/exec/CalulatePatientCountMainFromItemKey.java
@@ -249,10 +249,10 @@ public class CalulatePatientCountMainFromItemKey extends CRCDAO {
 			return strWriter.toString();
 
 		} catch (Exception sqlEx) {
-			log.error("QueryResultPatientSetGenerator.generateResult:"
+			log.error("CalulatePatientCountMainFromItemKey.buildXmlResult:"
 					+ sqlEx.getMessage(), sqlEx);
 			throw new I2B2DAOException(
-					"QueryResultPatientSetGenerator.generateResult:"
+					"CalulatePatientCountMainFromItemKey.buildXmlResult:"
 							+ sqlEx.getMessage(), sqlEx);
 		} finally {
 			try {


### PR DESCRIPTION
Some of the exception messages and logging messages were referencing a different class (QueryResultPatientSetGenerator) instead of their own.  This is a minor change, but will help when troubleshooting exceptions.
