### PR TITLE
Update QueryMasterSpringDao.java

### DIFF
--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryMasterSpringDao.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/QueryMasterSpringDao.java
@@ -487,7 +487,7 @@ public class QueryMasterSpringDao extends CRCDAO implements IQueryMasterDao {
 				+ getDbSchemaName()
 				+ "qt_query_master set name = ? where query_master_id = ? and delete_flag = ?";
 		int updatedRow = jdbcTemplate.update(sql, new Object[] { queryNewName,
-				masterId, DELETE_NO_FLAG });
+				Integer.parseInt(masterId), DELETE_NO_FLAG });
 		if (updatedRow < 1) {
 			throw new I2B2DAOException("Query with master id " + masterId
 					+ " not found");
@@ -529,7 +529,7 @@ public class QueryMasterSpringDao extends CRCDAO implements IQueryMasterDao {
 				+ "qt_query_master set delete_flag =?,delete_date=? where query_master_id = ? and delete_flag = ?";
 		Date deleteDate = new Date(System.currentTimeMillis());
 		int queryMasterCount = jdbcTemplate.update(queryMasterSql,
-				new Object[] { DELETE_YES_FLAG, deleteDate, masterId,
+				new Object[] { DELETE_YES_FLAG, deleteDate, Integer.parseInt(masterId),
 				DELETE_NO_FLAG });
 		if (queryMasterCount < 1) {
 			throw new I2B2DAOException("Query not found with masterid =["
@@ -537,10 +537,10 @@ public class QueryMasterSpringDao extends CRCDAO implements IQueryMasterDao {
 		}
 
 		int queryInstanceCount = jdbcTemplate.update(queryInstanceSql,
-				new Object[] { DELETE_YES_FLAG, masterId, DELETE_NO_FLAG });
+				new Object[] { DELETE_YES_FLAG, Integer.parseInt(masterId), DELETE_NO_FLAG });
 		log.debug("Total no. of query instance deleted" + queryInstanceCount);
 		int queryResultInstanceCount = jdbcTemplate.update(resultInstanceSql,
-				new Object[] { DELETE_YES_FLAG, masterId });
+				new Object[] { DELETE_YES_FLAG, Integer.parseInt(masterId) });
 		log.debug("Total no. of query result deleted "
 				+ queryResultInstanceCount);
 	}


### PR DESCRIPTION
Error is thrown when deleting or renaming previous queries, e.g. 			
```
[ERROR] org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [update i2b2demodata.qt_query_master set: ERROR: operator does not exist: integer = character varying
[ERROR]   Hint: No operator matches the given name and argument type(s). You might need to add explicit type casts.
```
Occured like this in my virtual machine version 1708b.