### PR TITLE
use alias for index hint

### DIFF
--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/querybuilder/BuildTempTableSql.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/querybuilder/BuildTempTableSql.java
@@ -347,7 +347,7 @@ public class BuildTempTableSql extends CRCDAO {
 					"provider_dimension")) {
 				sqlHintClause = " /*+ index(observation_fact observation_fact_pk) */ ";
 			} else {
-				sqlHintClause = " /*+ index(observation_fact fact_cnpt_pat_enct_idx) */ ";
+				sqlHintClause = " /*+ index(f fact_cnpt_pat_enct_idx) */ ";
 			}
 
 			ModifierType modifierType = this.getModifierMetadataFromOntology(itemType);

--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/querybuilder/temporal/TemporalPanelConceptItem.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/dao/setfinder/querybuilder/temporal/TemporalPanelConceptItem.java
@@ -40,7 +40,7 @@ public class TemporalPanelConceptItem extends TemporalPanelItem {
 				if (tableName.equalsIgnoreCase("provider_dimension")) {
 					return " /*+ index(observation_fact observation_fact_pk) */ ";
 				} else {
-					return " /*+ index(observation_fact fact_cnpt_pat_enct_idx) */ ";
+					return " /*+ index(f fact_cnpt_pat_enct_idx) */ ";
 				}
 			}
 			return "";


### PR DESCRIPTION
After doing some testing at KUMC and reading an article at http://www.dba-oracle.com/t_oracle_index_hint_syntax.htm , it seems like i2b2 oracle index hint syntax is wrong. 

Here is what articles says: `Also note that of you alias the table, you must use the alias in the index hint:` `select /*+ index(c cust_primary_key_idx) */ * from customer c;`.

I also found this true in my testing.

Previously, I posted this as issue at https://github.com/i2b2/i2b2-transmart-etl/issues/2 (just for cross reference) 