### PR TITLE
Feature/ldap upn

### DIFF
--- a/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/util/QueryProcessorUtil.java
+++ b/edu.harvard.i2b2.crc/src/server/edu/harvard/i2b2/crc/util/QueryProcessorUtil.java
@@ -148,7 +148,7 @@ public class QueryProcessorUtil {
 					thisInstance = i;
 					serviceLocator = ServiceLocator.getInstance();
 
-					/* 
+					
 					pqMedium = new ProcessQueue(QueryManagerBeanUtil.MEDIUM_QUEUE);
 					pqLarge = new ProcessQueue( QueryManagerBeanUtil.LARGE_QUEUE);
 
@@ -160,7 +160,7 @@ public class QueryProcessorUtil {
 					Thread m2 = new Thread(pqLarge);
 					m2.start();
 					log.info("started LARGE");
-					 */
+					
 				}
 			}
 

--- a/edu.harvard.i2b2.pm/src/edu/harvard/i2b2/pm/util/SecurityAuthenticationLDAP.java
+++ b/edu.harvard.i2b2.pm/src/edu/harvard/i2b2/pm/util/SecurityAuthenticationLDAP.java
@@ -67,11 +67,12 @@ public class SecurityAuthenticationLDAP implements SecurityAuthentication {
 		securityAuthentication = (String) params.get("security_authentication");
 		securityAuthentication = securityAuthentication.toUpperCase();
 		setSSL = (String) params.get("ssl");
-		dn = (String) params.get("distinguished_name");
+		
 		if (searchBase.startsWith("@"))
 		{
-			principalName = dn + username + searchBase;
+			principalName = username + searchBase;
 		} else {
+			dn = (String) params.get("distinguished_name");
 			principalName = dn + username + "," + searchBase;
 		}
 		

--- a/edu.harvard.i2b2.pm/src/edu/harvard/i2b2/pm/util/SecurityAuthenticationLDAP.java
+++ b/edu.harvard.i2b2.pm/src/edu/harvard/i2b2/pm/util/SecurityAuthenticationLDAP.java
@@ -68,7 +68,12 @@ public class SecurityAuthenticationLDAP implements SecurityAuthentication {
 		securityAuthentication = securityAuthentication.toUpperCase();
 		setSSL = (String) params.get("ssl");
 		dn = (String) params.get("distinguished_name");
-		principalName = dn + username + "," + searchBase;
+		if (searchBase.startsWith("@"))
+		{
+			principalName = dn + username + searchBase;
+		} else {
+			principalName = dn + username + "," + searchBase;
+		}
 		
 		// DIGEST-MD5 configuration from the parameters
 		securityLayer = (String) params.get("security_layer");

--- a/edu.harvard.i2b2.pm/src/edu/harvard/i2b2/pm/ws/PMService.java
+++ b/edu.harvard.i2b2.pm/src/edu/harvard/i2b2/pm/ws/PMService.java
@@ -48,7 +48,7 @@ public class PMService {
 	private static Log log = LogFactory.getLog(PMService.class);
 
 	private static String msgVersion = "1.1";
-	private static String i2b2Version = "1.7.11";
+	private static String i2b2Version = "1.7.12a";
 
 	public String getVersion()
 	{


### PR DESCRIPTION
Active Directory enables other methods of binding which are more flexible besides just using the distinguished name.  https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6a5891b8-928e-4b75-a4a5-0e3b77eaca52.  This change is to enable binding the the User Principle Name form, which is very convenient when the distinguished names for users is not easily available (OU by department, etc.).

"For AD DS, the name forms are tried in the order they are listed below. For AD LDS, the name forms are tried in the order below, except that forms marked "Only for AD DS" are not tried, and the User Principal Name (UPN) mapping (the second form below) is tried last.

The name forms are:

    The DN of the object.

    The user principal name (UPN) of the object. The UPN of an object is either:

        A value of the userPrincipalName attribute of the object, or

        Only for AD DS: The value of the sAMAccountName attribute of the object, followed by a "@" sign, followed by either:

            The DNS name of a domain in the same forest as the object, or

            A value in the uPNSuffixes attribute of the Partitions container in the config NC replica."